### PR TITLE
Processing of DDEATH messages

### DIFF
--- a/mqtt_if.py
+++ b/mqtt_if.py
@@ -110,12 +110,16 @@ class MQTTInterface(object):
                     dev_metric = dev.get_metric(metric.name)
                     if dev_metric:
                         dev.update_metric(metric)
-                        print("DDATA from device %s/%s/%s" % (eon.birth_topic.group_id,
-                                                              eon.birth_topic.edge_node_id,
-                                                              dev.birth_topic.device_id))
+                        print("DDATA from device %s" % dev.get_short_handle())
                         dev.print_metric(dev_metric)
                     else:
                         print("No match for metric in device")
+        elif topic.is_ddeath():
+            dev = sp_net.find_dev(topic)
+            eon = sp_net.find_eon(topic)
+            if dev is not None and eon is not None:
+                print("Device %s died" % dev.get_short_handle())
+                eon.remove_dev(dev)
 
         loggers = sp_logger.SPLogger.get_all_matching_topic(msg.topic)
         for logger in loggers:

--- a/sp_dev.py
+++ b/sp_dev.py
@@ -137,4 +137,4 @@ class EdgeNode(SPDev):
 
     def remove_dev(self, device):
         """Removes a device from EdgeNode."""
-        self.devices = [dev for dev in self.devices if dev != device]
+        self.devices.remove(device)

--- a/sp_dev.py
+++ b/sp_dev.py
@@ -115,6 +115,12 @@ class SPDev:
         else:
             print(metric_str)
 
+    def get_short_handle(self):
+        """Returns a string representing the device."""
+        return "%s/%s/%s" % (self.birth_topic.group_id,
+                             self.edge_node_id,
+                             self.birth_topic.device_id)
+
 
 class EdgeNode(SPDev):
     """Edge of Network Node."""
@@ -124,5 +130,11 @@ class EdgeNode(SPDev):
 
     def add_dev(self, device):
         """Adds a device to EdgeNode."""
-        # TODO: check if device does not already exist.
-        self.devices.append(device)
+        if device in self.devices:
+            print("Device %s already exists" % dev.get_short_handle())
+        else:
+            self.devices.append(device)
+
+    def remove_dev(self, device):
+        """Removes a device from EdgeNode."""
+        self.devices = [dev for dev in self.devices if dev != device]

--- a/sp_topic.py
+++ b/sp_topic.py
@@ -46,6 +46,10 @@ class SparkplugTopic:
         """True for device data topics."""
         return self.message_type == "DDATA"
 
+    def is_ddeath(self):
+        """True for device death topics."""
+        return self.message_type == "DDEATH"
+
     def eon_id(self):
         """Return Edge of Network Node ID."""
         return self.edge_node_id


### PR DESCRIPTION
When receiving a DDEATH messahe for a known device, it is removed from the EoN's device list.

Also, removed a TODO by adding a log if we try to add a device that is already known and reworked some logs.