### PR TITLE
Build the docker image on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - 'main'
 
 env:
   REGISTRY: ghcr.io
@@ -45,8 +48,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and push
+      - name: Build only
+        if: ${{ github.event_name == 'push' }}
         id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.get_version.outputs.GHCR_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push
+        if: ${{ github.event_name != 'push' }}
+        id: docker_build_push
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build only
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name != 'push' }}
         id: docker_build
         uses: docker/build-push-action@v3
         with:
@@ -59,7 +59,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Build and push
-        if: ${{ github.event_name != 'push' }}
+        if: ${{ github.event_name == 'push' }}
         id: docker_build_push
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
The workflow will trigger the build on PRs, in addition with when pushing a tag, but this time without actually pushing the result on the container repo