### PR TITLE
Allow sending metrics with null values

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -27,10 +27,7 @@ jobs:
       - name: Install python dependencies
         working-directory: enki
         run: |
-          pip install -r requirements.txt
-          pip install pylint==2.17.5
-          pip install pylint-protobuf==0.20.2
-
+          pip install -r requirements_pylint.txt
       - name: Running pylint
         working-directory: enki
         run: |

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -28,8 +28,8 @@ jobs:
         working-directory: enki
         run: |
           pip install -r requirements.txt
-          pip install pylint
-          pip install pylint-protobuf
+          pip install pylint==2.17.5
+          pip install pylint-protobuf==0.20.2
 
       - name: Running pylint
         working-directory: enki

--- a/requirements_pylint.txt
+++ b/requirements_pylint.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+pylint==2.17.5
+pylint-protobuf==0.20.2


### PR DESCRIPTION
When a metric value is prompted, the user can press Ctrl-D to indicate the metric should be sent with the null flag.